### PR TITLE
fix packet disassembler bug; flag did not reset

### DIFF
--- a/src/main/scala/PacketAssembler/disassembler.scala
+++ b/src/main/scala/PacketAssembler/disassembler.scala
@@ -322,6 +322,7 @@ class PacketDisAssembler extends Module {
     }
     .elsewhen (state === idle) {
       flag_aa_valid := false.B
+      flag_aa := true.B
     }
 
   //Flag_crc
@@ -342,6 +343,7 @@ class PacketDisAssembler extends Module {
     }
     .elsewhen (state === idle) {
       flag_crc_valid := false.B
+      flag_crc := true.B
     }
 
   //out_valid


### PR DESCRIPTION
previously the flag for aa and crc did not reset between packets which led to errors in dma; fixed the bug now