### PR TITLE
broke packet disassembler preamble correlation threshold to top level io

### DIFF
--- a/src/main/scala/PacketAssembler/assembler.scala
+++ b/src/main/scala/PacketAssembler/assembler.scala
@@ -31,7 +31,7 @@ class ParameterBundle extends Bundle {
   val crcSeed = UInt(24.W)
   val whiteSeed = UInt(7.W)
   val aaDisassembler = UInt(32.W)
-
+  val thresDisassembler = UInt(3.W)
   override def cloneType: this.type = ParameterBundle().asInstanceOf[this.type]
 }
 

--- a/src/main/scala/PacketAssembler/disassembler.scala
+++ b/src/main/scala/PacketAssembler/disassembler.scala
@@ -217,7 +217,7 @@ class PacketDisAssembler extends Module {
     }.elsewhen(state === preamble) {
       val cor = ~(data.asUInt ^ preamble01)
       val ones = PopCount(cor)
-      when (ones >= threshold) {
+      when (ones > io.param.thresDisassembler) {
         state := aa
         counter := 0.U
         counter_byte := 0.U

--- a/src/test/scala/PacketAssembler_test/PacketDisassemblerTester.scala
+++ b/src/test/scala/PacketAssembler_test/PacketDisassemblerTester.scala
@@ -47,6 +47,7 @@ class PacketDisAssemblerTest(c: PacketDisAssembler) extends PeekPokeTester(c) {
     poke(c.io.param.whiteSeed, "b1100101".U)
     val aa = BigInt(packet(3) + packet(2) + packet(1) + packet(0), 2)
     poke(c.io.param.aaDisassembler, aa.U)
+    poke(c.io.param.thresDisassembler, 7.U)
 
     //initialize
     poke(c.io.in.switch, false.B)


### PR DESCRIPTION
correlation threshold is a way for packet disassembler to deal with noise in preamble; now it's in the top level io and can be set by user. The value of threshold should be between 0 and 7; it is being compared with the correlation between input data and preamble (either 01010101 or 10101010). Correlation is calculated by counting the number of one's when xor'ing these two values