### PR TITLE
Pre preamble

### DIFF
--- a/src/main/scala/PacketAssembler/assembler.scala
+++ b/src/main/scala/PacketAssembler/assembler.scala
@@ -30,6 +30,7 @@ object PAInputBundle {
 class ParameterBundle extends Bundle {
   val crcSeed = UInt(24.W)
   val whiteSeed = UInt(7.W)
+  val prepreamble = Bool()
   val aaDisassembler = UInt(32.W)
   val thresDisassembler = UInt(3.W)
   override def cloneType: this.type = ParameterBundle().asInstanceOf[this.type]
@@ -302,7 +303,7 @@ class PacketAssembler extends Module {
   } .elsewhen (state === preamble) {
       when (io.in.data.valid) {
         when(counter === 0.U){
-          data := Mux(io.in.data.bits(0) === 0.U, prepreamble0, prepreamble1)
+          data := Mux(io.param.prepreamble, Mux(io.in.data.bits(0) === 0.U, prepreamble0, prepreamble1), 0.U)
         }.otherwise {
           data := Mux(io.in.data.bits(0) === 0.U, preamble0, preamble1)
         }

--- a/src/main/scala/PacketAssembler/assembler.scala
+++ b/src/main/scala/PacketAssembler/assembler.scala
@@ -271,7 +271,7 @@ class PacketAssembler extends Module {
   when (state === idle) {
     out_valid := false.B
   } .elsewhen (state === preamble) {
-      when (counter === 1.U && counter_byte === 7.U && out_fire) {
+      when (counter_byte === 7.U && out_fire) {
         out_valid := false.B //special case at the end of PREAMBLE: aa starts with invalid
       } .elsewhen (io.in.data.valid) {
         out_valid := true.B

--- a/src/main/scala/SoftwareGoldenModel.scala
+++ b/src/main/scala/SoftwareGoldenModel.scala
@@ -149,16 +149,19 @@ object SoftwareGoldenModel {
   def pa_sw(packetIn: Array[String]): (Array[String]) = {
 
     val len = packetIn.size
-    val buf = new Array[String](len + 4)
+    val buf = new Array[String](len + 5)
     val preamble =
       if (packetIn(0).slice(7, 8) == "0") "10101010" else "01010101"
+    val prepreamble = 
+      if (packetIn(0).slice(7, 8) == "0") "00001111" else "11110000"
     var crc_lfsr = "010101010101010101010101".reverse
     var white_lfsr = "1100101"
 
-    buf(0) = preamble
+    buf(0) = prepreamble
+    buf(1) = preamble
     for (i <- 0 to len + 2) {
       if (i < 4) {
-        buf(i + 1) = packetIn(i)
+        buf(i + 2) = packetIn(i)
       } else {
         var stringOut: String = ""
         var bitIn: Int = 0
@@ -176,7 +179,7 @@ object SoftwareGoldenModel {
           white_lfsr = init_res._2
           stringOut = stringOut + bitOut.toString
         }
-        buf(i + 1) = stringOut.reverse
+        buf(i + 2) = stringOut.reverse
       }
     }
     return buf

--- a/src/test/scala/PacketAssembler_test/PacketAssemblerTester.scala
+++ b/src/test/scala/PacketAssembler_test/PacketAssemblerTester.scala
@@ -60,18 +60,19 @@ class PacketAssemblerTest(c: PacketAssembler) extends PeekPokeTester(c) {
 
     //Preamble
     sendBits(packetInt(0), sw_out(0), 8)
+    sendBits(packetInt(0), sw_out(1), 8)
 
     //AA and PDU
     for (j <- 0 to len - 1) {
-      sendBits(packetInt(j), sw_out(j + 1), 8)
+      sendBits(packetInt(j), sw_out(j + 2), 8)
     }
 
     //CRC
     for (j <- 0 to 23) {
       step(5)
       poke(c.io.out.data.ready, true.B)
-      expect(c.io.out.data.bits, sw_out(len + 1 + j / 8).U(j % 8)) //note
-      //println(s"j="+j+s"\n${peek(c.io.out.data.bits)}\t${peek(sw_out(len + 1 + j / 8).U(j % 8))}")
+      expect(c.io.out.data.bits, sw_out(len + 2 + j / 8).U(j % 8)) //note
+      //println(s"j="+j+s"\n${peek(c.io.out.data.bits)}\t${peek(sw_out(len + 2 + j / 8).U(j % 8))}")
       step(1)
       poke(c.io.out.data.ready, false.B)
     }

--- a/src/test/scala/PacketAssembler_test/PacketAssemblerTester.scala
+++ b/src/test/scala/PacketAssembler_test/PacketAssemblerTester.scala
@@ -43,6 +43,7 @@ class PacketAssemblerTest(c: PacketAssembler) extends PeekPokeTester(c) {
     //throughout packet
     poke(c.io.param.crcSeed, "b010101010101010101010101".U)
     poke(c.io.param.whiteSeed, "b1100101".U)
+    poke(c.io.param.prepreamble, true.B)
 
     //initialize
     poke(c.io.in.trigger, false.B)

--- a/src/test/scala/PacketAssembler_test/PacketDisassemblerTester.scala
+++ b/src/test/scala/PacketAssembler_test/PacketDisassemblerTester.scala
@@ -65,6 +65,19 @@ class PacketDisAssemblerTest(c: PacketDisAssembler) extends PeekPokeTester(c) {
     poke(c.io.in.switch, false.B)
 
     //PREAMBLE
+    if(i % 2 == 0){
+      for (j <- 0 to 7) {
+        poke(c.io.out.data.ready, true.B)
+        poke(c.io.in.data.bits, sw_out(0).U(j)) //note: U to B
+        expect(c.io.out.data.valid, false.B)
+        step(1)
+        poke(c.io.out.data.ready, false.B)
+      }
+      poke(c.io.in.data.valid, false.B)
+      step(10)
+      poke(c.io.in.data.valid, true.B)
+    }
+
     for (j <- 0 to 7) {
       poke(c.io.out.data.ready, true.B)
       poke(c.io.in.data.bits, sw_out(1).U(j)) //note: U to B

--- a/src/test/scala/PacketAssembler_test/PacketDisassemblerTester.scala
+++ b/src/test/scala/PacketAssembler_test/PacketDisassemblerTester.scala
@@ -67,17 +67,6 @@ class PacketDisAssemblerTest(c: PacketDisAssembler) extends PeekPokeTester(c) {
     //PREAMBLE
     for (j <- 0 to 7) {
       poke(c.io.out.data.ready, true.B)
-      poke(c.io.in.data.bits, sw_out(0).U(j)) //note: U to B
-      expect(c.io.out.data.valid, false.B)
-      step(1)
-      poke(c.io.out.data.ready, false.B)
-    }
-    poke(c.io.in.data.valid, false.B)
-    step(10)
-    poke(c.io.in.data.valid, true.B)
-
-    for (j <- 0 to 7) {
-      poke(c.io.out.data.ready, true.B)
       poke(c.io.in.data.bits, sw_out(1).U(j)) //note: U to B
       expect(c.io.out.data.valid, false.B)
       step(1)

--- a/src/test/scala/PacketAssembler_test/PacketDisassemblerTester.scala
+++ b/src/test/scala/PacketAssembler_test/PacketDisassemblerTester.scala
@@ -74,10 +74,21 @@ class PacketDisAssemblerTest(c: PacketDisAssembler) extends PeekPokeTester(c) {
     }
     poke(c.io.in.data.valid, false.B)
     step(10)
+    poke(c.io.in.data.valid, true.B)
+
+    for (j <- 0 to 7) {
+      poke(c.io.out.data.ready, true.B)
+      poke(c.io.in.data.bits, sw_out(1).U(j)) //note: U to B
+      expect(c.io.out.data.valid, false.B)
+      step(1)
+      poke(c.io.out.data.ready, false.B)
+    }
+    poke(c.io.in.data.valid, false.B)
+    step(10)
 
     //AA and PDU
     for (j <- 0 to len - 1) {
-      sendBits(sw_out(j + 1), packetInt(j), 8)
+      sendBits(sw_out(j + 2), packetInt(j), 8)
     }
 
     expect(c.io.out.flag_aa.bits, true.B)
@@ -85,7 +96,7 @@ class PacketDisAssemblerTest(c: PacketDisAssembler) extends PeekPokeTester(c) {
 
     // CRC
     for (j <- 0 to 23) {
-      poke(c.io.in.data.bits, sw_out(len + 1 + j / 8).U(j % 8))
+      poke(c.io.in.data.bits, sw_out(len + 2 + j / 8).U(j % 8))
       poke(c.io.in.data.valid, true.B)
       poke(c.io.out.data.ready, true.B)
       if (j % 8 == 7) {


### PR DESCRIPTION
implemented pre-preamble in packet assembler
content of pre-preamble depends on the first bit of packet: 11110000 if first bit 0, 00001111 if first bit 1
the inclusion of pre-preamble increases the robustness of ble baseband, provides an extra edge for cdr modules, and avoid potential scenarios where the first bit of packet preamble is missed and the entire packet is compromised